### PR TITLE
Fix DB connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       context: ./backend
     ports:
       - "8080:8080"
-    env_file:
-      - .env
+    environment:
+      DB_DSN: "root:clave123@tcp(mysql-gimnasio:3306)/gimnasio?charset=utf8mb4&parseTime=True&loc=Local"
     depends_on:
       - mysql-gimnasio
 


### PR DESCRIPTION
## Summary
- configure backend DB connection string directly in docker-compose so MySQL credentials match
- quote DSN string to ensure YAML parsing

## Testing
- `go vet ./...` *(fails: could not download modules due to network restrictions)*
- `npm test --silent` *(no output; no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f2e41ab888333831aab9979debedc