### PR TITLE
Fix admin flag in auth context

### DIFF
--- a/backend/controller/gym_controller.go
+++ b/backend/controller/gym_controller.go
@@ -140,9 +140,10 @@ func ValidateToken(contexto *gin.Context) {
 		return
 	}
 
-	contexto.Set("userID", token.Claims.(*claims).ID)
-	contexto.Set("email", token.Claims.(*claims).Subject) // Capaz innecesario
-	contexto.Next()
+       contexto.Set("userID", token.Claims.(*claims).ID)
+       contexto.Set("email", token.Claims.(*claims).Subject) // Capaz innecesario
+       contexto.Set("isAdmin", token.Claims.(*claims).IsAdmin)
+       contexto.Next()
 }
 
 func GetActividades(contexto *gin.Context) {


### PR DESCRIPTION
## Summary
- set `isAdmin` in the auth middleware
- keep handler admin checks using `GetBool("isAdmin")`

## Testing
- `go vet ./...` *(fails: forbidden to download modules)*
- `npm test --silent` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685f371cda6083338627e36e1171cc2a