### PR TITLE
Use backend URL env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+# Environment configuration for development and docker-compose
+
+# Local development backend URL
+VITE_BACKEND_URL=http://localhost:8080
+
+# When running with docker-compose uncomment the line below
+# VITE_BACKEND_URL=http://backend-gimnasio:8080

--- a/frontend/src/Actividades.jsx
+++ b/frontend/src/Actividades.jsx
@@ -143,7 +143,7 @@ function Actividades() {
       const token = localStorage.getItem("token");
       if (!token) { navigate("/"); return; }
       try {
-        const resp = await fetch("http://localhost:8080/inscripciones", {
+        const resp = await fetch(`${import.meta.env.VITE_BACKEND_URL}/inscripciones`, {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!resp.ok) throw new Error();
@@ -171,7 +171,7 @@ function Actividades() {
         if (filtrosAplicados.horario) params.append('horario', filtrosAplicados.horario);
         params.append('page', actualPage.toString());
 
-        const resp = await fetch(`http://localhost:8080/actividades?${params.toString()}`);
+        const resp = await fetch(`${import.meta.env.VITE_BACKEND_URL}/actividades?${params.toString()}`);
         if (!resp.ok) throw new Error();
 
         const data = await resp.json();

--- a/frontend/src/Inscripcion.jsx
+++ b/frontend/src/Inscripcion.jsx
@@ -7,8 +7,8 @@ const handleInscribir = async (actividadID, alreadyInscribed) => {
     }
 
     const url = alreadyInscribed
-        ? 'http://localhost:8080/unscripcion'
-        : 'http://localhost:8080/inscripcion';
+        ? `${import.meta.env.VITE_BACKEND_URL}/unscripcion`
+        : `${import.meta.env.VITE_BACKEND_URL}/inscripcion`;
 
     try {
         const response = await fetch(url, {

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -15,7 +15,7 @@ const Login = () => {
 
     try {
       const passwordHash = await hashPassword(password);
-      const response = await fetch('http://localhost:8080/login', {
+      const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password: passwordHash }), // FALTA HASHEAR CONTRASEÑA

--- a/frontend/src/MisActividades.jsx
+++ b/frontend/src/MisActividades.jsx
@@ -87,7 +87,7 @@ const MisActividades = () => {
       }
 
       try {
-        const response = await fetch("http://localhost:8080/misactividades", {
+        const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/misactividades`, {
           headers: { Authorization: `Bearer ${token}` },
         });
 


### PR DESCRIPTION
## Summary
- reference `VITE_BACKEND_URL` in frontend API calls
- document `VITE_BACKEND_URL` usage in `.env`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f371e3888833398efe8b20a4412e3