### PR TITLE
Adjust mysql host port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ VITE_BACKEND_URL=http://localhost:8080
 ```
 
 Ajuste los valores de las variables `DB_*` según su entorno en caso de ser necesario.
+El contenedor de MySQL se expone en el puerto 3307 del host (`3307:3306`). Si necesita utilizar otro puerto, cambie el valor antes de los dos puntos en `docker-compose.yml`.
 
 ## Construcción y ejecución con Docker Compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     ports:
-      - "3306:3306"
+      - "3307:3306" # ajuste el puerto del host si es necesario
 
   backend-gimnasio:
     build:


### PR DESCRIPTION
## Summary
- expose mysql on host port 3307 and add a comment
- document how to change the host port for the database

## Testing
- `docker compose up --build` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f3c6559d88333a4d5ffbd448e6172