### PR TITLE
Use .env for backend config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
   backend-gimnasio:
     build:
       context: ./backend
+    env_file:
+      - .env
     ports:
       - "8080:8080"
-    environment:
-      DB_DSN: "root:clave123@tcp(mysql-gimnasio:3306)/gimnasio?charset=utf8mb4&parseTime=True&loc=Local"
     depends_on:
       - mysql-gimnasio
 


### PR DESCRIPTION
## Summary
- load backend variables from `.env` in docker-compose

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go vet ./...` in `backend` *(fails due to missing network access)*
- `npm test --silent` *(fails: no output, likely missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_685f3e6541348333a8247dd12bc9bccc