### PR TITLE
Extend DB retry loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ docker-compose up --build
 
 El backend quedará disponible en `http://localhost:8080` y el frontend en `http://localhost:3000`.
 
+El código del backend realiza hasta 40 intentos de conexión a la base de datos,
+esperando 5 segundos entre cada uno. Esto permite que MySQL termine de iniciarse
+antes de que el servicio falle.
+
 Para detener los contenedores utilice `docker-compose down`.
 
 ## Pruebas

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -27,13 +27,13 @@ func ConectarBD() {
 
 	var err error
 
-	for i := 1; i <= 20; i++ {
+	for i := 1; i <= 40; i++ {
 		DB, err = gorm.Open(mysql.Open(dsn), &gorm.Config{})
 		if err == nil {
 			break
 		}
-		fmt.Printf("⏳ Esperando conexión con la base de datos (intento %d/20): %s\n", i, err.Error())
-		time.Sleep(3 * time.Second)
+		fmt.Printf("⏳ Esperando conexión con la base de datos (intento %d/40): %s\n", i, err.Error())
+		time.Sleep(5 * time.Second)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- increase database retry attempts in `ConectarBD`
- note the change in the README

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `npm test` *(fails: Missing script "test" and blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_685f3e6778fc83339d24db8b8e3f62bd