### PR TITLE
Add DB_DSN variable to env example

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,5 +1,8 @@
 # Environment configuration for development and docker-compose
 
+# Connection string for MySQL used by the backend
+DB_DSN=root:clave123@tcp(mysql-gimnasio:3306)/gimnasio?charset=utf8mb4&parseTime=True&loc=Local
+
 # Local development backend URL
 VITE_BACKEND_URL=http://localhost:8080
 


### PR DESCRIPTION
## Summary
- include `DB_DSN` in `example.env`

## Testing
- `go vet ./...` *(fails: could not download toolchain)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f44f810348333befdf966d5cd4433