### PR TITLE
refactor: remove radix label dependency

### DIFF
--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,16 +1,15 @@
 "use client"
 
 import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
 
 import { cn } from "@/lib/utils"
 
 function Label({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.LabelHTMLAttributes<HTMLLabelElement>) {
   return (
-    <LabelPrimitive.Root
+    <label
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",


### PR DESCRIPTION
## Summary
- replace Radix label component with native `<label>` to avoid missing dependency

## Testing
- `npm run lint` *(fails: Unknown options in lint configuration)*
- `npm run build` *(fails: Module not found for '@radix-ui/react-separator' and '@vercel/analytics/next')*

------
https://chatgpt.com/codex/tasks/task_e_68b379fc5b708333a2c00e1c1cef7d32